### PR TITLE
Add 301 redirects for old site 404 URLs

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -13,6 +13,145 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  async redirects() {
+    return [
+      // =============================================
+      // Old www.alliancemedsupply.com pages (Wix site)
+      // =============================================
+
+      // Core pages
+      { source: '/home', destination: '/', permanent: true },
+      { source: '/about', destination: '/about-us', permanent: true },
+      {
+        source: '/map-directions',
+        destination: '/contact-us',
+        permanent: true,
+      },
+      { source: '/gallery', destination: '/', permanent: true },
+      { source: '/terms-conditions', destination: '/', permanent: true },
+
+      // Old product/rental pages → matching new categories
+      { source: '/rentals', destination: '/products', permanent: true },
+      { source: '/shop', destination: '/products', permanent: true },
+      {
+        source: '/wheelchair-rentals',
+        destination: '/products/wheelchairs',
+        permanent: true,
+      },
+      {
+        source: '/hospital-bed-rentals',
+        destination: '/products/electric-hospital-beds-and-mattresses',
+        permanent: true,
+      },
+      {
+        source: '/rollator',
+        destination: '/products/rollators',
+        permanent: true,
+      },
+      {
+        source: '/walker-rentals',
+        destination: '/products/rollators',
+        permanent: true,
+      },
+      {
+        source: '/power-chair',
+        destination: '/products/electric-wheelchairs',
+        permanent: true,
+      },
+      {
+        source: '/scooters',
+        destination: '/products/mobility-scooters',
+        permanent: true,
+      },
+      {
+        source: '/lift-chair',
+        destination: '/products/lift-chair',
+        permanent: true,
+      },
+      {
+        source: '/hoyer-lift',
+        destination: '/products/stand-assists-and-lifts',
+        permanent: true,
+      },
+
+      // Old product pages → best matching category
+      {
+        source: '/low-air-loss-matress',
+        destination: '/products/electric-hospital-beds-and-mattresses',
+        permanent: true,
+      },
+      {
+        source: '/alternating-pressure-pad-and-pump',
+        destination: '/products/electric-hospital-beds-and-mattresses',
+        permanent: true,
+      },
+
+      // Discontinued/specialty products → products page
+      { source: '/laser-touch-one', destination: '/products', permanent: true },
+      {
+        source: '/cold-circulating-unit',
+        destination: '/products',
+        permanent: true,
+      },
+      {
+        source: '/suction-machine',
+        destination: '/products',
+        permanent: true,
+      },
+
+      // Old service pages → contact
+      {
+        source: '/home-assesment',
+        destination: '/contact-us',
+        permanent: true,
+      },
+      {
+        source: '/parts-repair',
+        destination: '/contact-us',
+        permanent: true,
+      },
+
+      // Wix placeholder product pages
+      {
+        source: '/product-page/:slug',
+        destination: '/products',
+        permanent: true,
+      },
+
+      // Wix internal API routes
+      { source: '/_api/:path*', destination: '/', permanent: true },
+
+      // =============================================
+      // Old store.alliancemedsupply.com (Booqable store)
+      // These only work if the store subdomain is pointed
+      // at this Vercel deployment.
+      // =============================================
+      {
+        source: '/web_store/items/:id(\\d+)',
+        destination: 'https://www.alliancemedsupply.com/products',
+        has: [{ type: 'host', value: 'store.alliancemedsupply.com' }],
+        permanent: true,
+      },
+      {
+        source: '/web_store/about_us',
+        destination: 'https://www.alliancemedsupply.com/about-us',
+        has: [{ type: 'host', value: 'store.alliancemedsupply.com' }],
+        permanent: true,
+      },
+      {
+        source: '/users/sign_in',
+        destination: 'https://www.alliancemedsupply.com/',
+        has: [{ type: 'host', value: 'store.alliancemedsupply.com' }],
+        permanent: true,
+      },
+      {
+        source: '/:path*',
+        destination: 'https://www.alliancemedsupply.com/products',
+        has: [{ type: 'host', value: 'store.alliancemedsupply.com' }],
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Adds 301 permanent redirects in `next.config.ts` for all 126 broken URLs reported in Google Search Console
- Maps old Wix site pages (wheelchair-rentals, hospital-bed-rentals, rollator, hoyer-lift, etc.) to their matching new product categories
- Redirects old Booqable store subdomain (`store.alliancemedsupply.com`) URLs to `www` (requires adding the subdomain to Vercel)
- All redirects use `permanent: true` (HTTP 301) to preserve SEO link equity

## Redirect mapping

**Product pages (highest SEO priority):**
- `/wheelchair-rentals` → `/products/wheelchairs`
- `/hospital-bed-rentals` → `/products/electric-hospital-beds-and-mattresses`
- `/rollator` → `/products/rollators`
- `/power-chair` → `/products/electric-wheelchairs`
- `/scooters` → `/products/mobility-scooters`
- `/hoyer-lift` → `/products/stand-assists-and-lifts`
- `/lift-chair` → `/products/lift-chair`
- `/low-air-loss-matress` → `/products/electric-hospital-beds-and-mattresses`
- `/alternating-pressure-pad-and-pump` → `/products/electric-hospital-beds-and-mattresses`

**General pages:**
- `/about` → `/about-us`
- `/home` → `/`
- `/rentals`, `/shop` → `/products`
- `/map-directions` → `/contact-us`
- `/home-assesment`, `/parts-repair` → `/contact-us`

**Store subdomain (requires DNS setup):**
- `store.alliancemedsupply.com/web_store/items/*` → `www.alliancemedsupply.com/products`
- Catch-all for remaining store URLs

## Post-merge steps
1. Merge and let Vercel deploy
2. (Optional) Add `store.alliancemedsupply.com` as a domain in Vercel project settings for store subdomain redirects
3. Go to Google Search Console → "Not found (404)" → click **Validate Fix**

## Test plan
- [ ] Verify build passes (confirmed locally)
- [ ] After deploy, test key redirects: `/wheelchair-rentals`, `/hospital-bed-rentals`, `/about`
- [ ] Confirm 301 status codes (not 302) using `curl -I`

🤖 Generated with [Claude Code](https://claude.com/claude-code)