### PR TITLE
feat: attach google tag manager script to html

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,7 +12,6 @@ import {
 } from '@/lib/seo';
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
-import Script from 'next/script';
 import './globals.css';
 
 const geistSans = Geist({
@@ -146,25 +145,29 @@ export default function RootLayout({
           async
           defer
         />
+
+        {/* Google Tag Manager */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-MKKD7MPV');`,
+          }}
+        />
+        {/* End Google Tag Manager */}
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
         suppressHydrationWarning
       >
-        {/* Google tag (gtag.js) */}
-        <Script
-          async
-          src="https://www.googletagmanager.com/gtag/js?id=AW-1033244256"
-          strategy="afterInteractive"
-        />
-        <Script id="google-analytics" strategy="afterInteractive">
-          {`
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-            gtag('config', 'AW-1033244256');
-          `}
-        </Script>
+        {/* Google Tag Manager (noscript) */}
+        <noscript>
+          <iframe
+            src="https://www.googletagmanager.com/ns.html?id=GTM-MKKD7MPV"
+            height="0"
+            width="0"
+            style={{ display: 'none', visibility: 'hidden' }}
+          />
+        </noscript>
+        {/* End Google Tag Manager (noscript) */}
 
         <Header />
         <main>{children}</main>


### PR DESCRIPTION
- Implement Google Tag Manger HTML

Header
<img width="2133" height="882" alt="Screenshot 2026-06-12 133628" src="https://github.com/user-attachments/assets/b6dd366b-18b6-48b2-b942-13db5b5868f2" />

Body
<img width="2146" height="906" alt="Screenshot 2026-06-12 133656" src="https://github.com/user-attachments/assets/ed10c14d-6f33-464c-a2cb-42ecacf4f6d2" />

Response
<img width="972" height="743" alt="image" src="https://github.com/user-attachments/assets/1846e734-02e1-4af6-b28f-f192545da180" />

