### PR TITLE
Add SEO-focused medical equipment blog

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,264 @@
+import { BlogCard } from '@/components/custom/blog';
+import { Button } from '@/components/ui/button';
+import { contact } from '@/data/contact';
+import {
+  blogPosts,
+  formatBlogDate,
+  getBlogPost,
+  getRelatedPosts,
+} from '@/lib/blog';
+import {
+  generateBreadcrumbSchema,
+  jsonLdScriptProps,
+  siteConfig,
+} from '@/lib/seo';
+import {
+  ArrowLeft,
+  CalendarDays,
+  CheckCircle2,
+  Clock3,
+  MapPin,
+  Phone,
+  ShieldCheck,
+} from 'lucide-react';
+import type { Metadata } from 'next';
+import Image from 'next/image';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+type PageProps = {
+  params: Promise<{ slug: string }>;
+};
+
+export function generateStaticParams() {
+  return blogPosts.map((post) => ({ slug: post.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const post = getBlogPost(slug);
+
+  if (!post) return { title: 'Article Not Found' };
+
+  const url = `${siteConfig.url}/blog/${post.slug}`;
+  return {
+    title: post.title,
+    description: post.excerpt,
+    keywords: post.keywords,
+    authors: [{ name: contact.businessName }],
+    alternates: { canonical: url },
+    openGraph: {
+      title: post.title,
+      description: post.excerpt,
+      url,
+      siteName: contact.businessName,
+      locale: siteConfig.locale,
+      type: 'article',
+      publishedTime: post.publishedAt,
+      modifiedTime: post.updatedAt ?? post.publishedAt,
+      authors: [contact.businessName],
+      section: post.category,
+      tags: post.keywords,
+      images: [{ url: post.image, alt: post.imageAlt }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: post.title,
+      description: post.excerpt,
+      images: [post.image],
+    },
+  };
+}
+
+export default async function BlogArticlePage({ params }: PageProps) {
+  const { slug } = await params;
+  const post = getBlogPost(slug);
+  if (!post) notFound();
+
+  const relatedPosts = getRelatedPosts(post);
+  const articleUrl = `${siteConfig.url}/blog/${post.slug}`;
+  const breadcrumbData = generateBreadcrumbSchema([
+    { name: 'Home', url: '/' },
+    { name: 'Blog', url: '/blog' },
+    { name: post.title, url: `/blog/${post.slug}` },
+  ]);
+  const articleSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: post.title,
+    description: post.excerpt,
+    image: post.image,
+    datePublished: post.publishedAt,
+    dateModified: post.updatedAt ?? post.publishedAt,
+    mainEntityOfPage: articleUrl,
+    articleSection: post.category,
+    keywords: post.keywords.join(', '),
+    author: {
+      '@type': 'Organization',
+      name: contact.businessName,
+      url: siteConfig.url,
+    },
+    publisher: { '@id': `${siteConfig.url}/#organization` },
+  };
+
+  return (
+    <div className="min-h-screen bg-white pt-20">
+      <script {...jsonLdScriptProps([breadcrumbData, articleSchema])} />
+
+      <header className="relative overflow-hidden border-b border-slate-200 bg-slate-50">
+        <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-teal-500 via-teal-400 to-orange-400" />
+        <div className="mx-auto max-w-5xl px-4 py-12 md:px-6 md:py-16 lg:px-8">
+          <Link
+            href="/blog"
+            className="inline-flex items-center gap-2 rounded-md text-sm font-bold text-teal-700 hover:text-teal-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-4"
+          >
+            <ArrowLeft className="h-4 w-4" /> Back to all guides
+          </Link>
+
+          <div className="mt-8 flex flex-wrap items-center gap-3">
+            <span className="rounded-full bg-teal-100 px-3 py-1.5 text-sm font-bold text-teal-800">
+              {post.category}
+            </span>
+            <span className="flex items-center gap-1.5 text-sm text-slate-500">
+              <CalendarDays className="h-4 w-4 text-teal-600" />
+              {formatBlogDate(post.publishedAt)}
+            </span>
+            <span className="flex items-center gap-1.5 text-sm text-slate-500">
+              <Clock3 className="h-4 w-4 text-orange-500" />
+              {post.readingTime}
+            </span>
+          </div>
+
+          <h1 className="mt-6 max-w-4xl text-4xl font-bold leading-tight tracking-tight text-slate-950 sm:text-5xl md:text-6xl">
+            {post.title}
+          </h1>
+          <p className="mt-6 max-w-3xl text-lg leading-8 text-slate-600 md:text-xl">
+            {post.excerpt}
+          </p>
+
+          <div className="mt-8 flex items-center gap-3 text-sm text-slate-600">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-teal-700 text-white">
+              <ShieldCheck className="h-5 w-5" />
+            </div>
+            <div>
+              <p className="font-bold text-slate-900">
+                Alliance Editorial Team
+              </p>
+              <p>Medical equipment education from San Jose, California</p>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div className="mx-auto max-w-6xl px-4 py-10 md:px-6 md:py-14 lg:px-8">
+        <div className="relative aspect-[16/8] overflow-hidden rounded-3xl bg-slate-100 shadow-sm">
+          <Image
+            src={post.image}
+            alt={post.imageAlt}
+            fill
+            priority
+            className="object-cover"
+            sizes="(max-width: 1200px) 100vw, 1152px"
+          />
+        </div>
+
+        <div className="mx-auto mt-12 grid max-w-5xl gap-12 lg:grid-cols-[minmax(0,1fr)_240px]">
+          <article className="min-w-0">
+            <p className="text-xl leading-9 text-slate-700">
+              {post.introduction}
+            </p>
+
+            <div className="mt-10 space-y-10">
+              {post.sections.map((section) => (
+                <section key={section.heading}>
+                  <h2 className="text-2xl font-bold tracking-tight text-slate-950 sm:text-3xl">
+                    {section.heading}
+                  </h2>
+                  <div className="mt-4 space-y-4 text-base leading-8 text-slate-700">
+                    {section.paragraphs.map((paragraph) => (
+                      <p key={paragraph}>{paragraph}</p>
+                    ))}
+                  </div>
+                  {section.bullets && (
+                    <ul className="mt-5 space-y-3 rounded-2xl border border-teal-100 bg-teal-50/70 p-6">
+                      {section.bullets.map((bullet) => (
+                        <li
+                          key={bullet}
+                          className="flex gap-3 text-base leading-7 text-slate-700"
+                        >
+                          <CheckCircle2 className="mt-1 h-5 w-5 flex-none text-teal-600" />
+                          <span>{bullet}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </section>
+              ))}
+            </div>
+
+            <div className="mt-12 rounded-2xl border-l-4 border-orange-500 bg-orange-50 p-6 sm:p-8">
+              <p className="text-sm font-bold uppercase tracking-[0.16em] text-orange-700">
+                The takeaway
+              </p>
+              <p className="mt-3 text-lg font-semibold leading-8 text-slate-900">
+                {post.takeaway}
+              </p>
+            </div>
+
+            <div className="mt-8 rounded-2xl border border-slate-200 bg-slate-50 p-6 text-sm leading-6 text-slate-600">
+              <strong className="text-slate-900">
+                Health information notice:
+              </strong>{' '}
+              This article is for general educational purposes and is not a
+              substitute for medical advice, diagnosis, or treatment. Follow the
+              instructions of your healthcare professional and equipment
+              manufacturer.
+            </div>
+          </article>
+
+          <aside className="lg:sticky lg:top-28 lg:h-fit">
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 p-6">
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-teal-700 text-white">
+                <Phone className="h-5 w-5" />
+              </div>
+              <h2 className="mt-4 text-lg font-bold text-slate-950">
+                Need help choosing equipment?
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-slate-600">
+                Speak with our local team about rental, purchase, delivery, and
+                setup options.
+              </p>
+              <Button asChild className="mt-5 w-full">
+                <a href={contact.phone.href}>Call {contact.phone.display}</a>
+              </Button>
+              <Link
+                href="/contact-us"
+                className="mt-3 flex items-center justify-center gap-2 text-sm font-bold text-teal-700 hover:text-teal-900"
+              >
+                <MapPin className="h-4 w-4" /> Visit or contact us
+              </Link>
+            </div>
+          </aside>
+        </div>
+      </div>
+
+      <section className="border-t border-slate-200 bg-slate-50">
+        <div className="mx-auto max-w-7xl px-4 py-14 md:px-6 md:py-20 lg:px-8">
+          <p className="text-sm font-bold uppercase tracking-[0.18em] text-teal-700">
+            Keep learning
+          </p>
+          <h2 className="mt-2 text-3xl font-bold tracking-tight text-slate-950">
+            Related guides
+          </h2>
+          <div className="mt-8 grid gap-7 md:grid-cols-2 lg:grid-cols-3">
+            {relatedPosts.map((relatedPost) => (
+              <BlogCard key={relatedPost.slug} post={relatedPost} />
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,256 @@
+import { BlogCard } from '@/components/custom/blog';
+import { Button } from '@/components/ui/button';
+import { contact } from '@/data/contact';
+import { blogPosts, formatBlogDate } from '@/lib/blog';
+import {
+  generateBreadcrumbSchema,
+  jsonLdScriptProps,
+  siteConfig,
+} from '@/lib/seo';
+import {
+  ArrowRight,
+  BookOpen,
+  CalendarDays,
+  CheckCircle2,
+  Clock3,
+  MapPin,
+  Sparkles,
+} from 'lucide-react';
+import type { Metadata } from 'next';
+import Image from 'next/image';
+import Link from 'next/link';
+
+const title = 'Medical Equipment & Home Healthcare Blog';
+const description =
+  'Practical medical equipment guides, home safety tips, mobility advice, and caregiver resources from Alliance Medical Supply in San Jose, California.';
+
+export const metadata: Metadata = {
+  title,
+  description,
+  keywords: [
+    'medical equipment blog',
+    'home healthcare tips',
+    'medical supplies guide',
+    'caregiver resources',
+    'wheelchair guide',
+    'hospital bed rental advice',
+    'Bay Area medical equipment',
+  ],
+  alternates: { canonical: `${siteConfig.url}/blog` },
+  openGraph: {
+    title,
+    description,
+    url: `${siteConfig.url}/blog`,
+    siteName: contact.businessName,
+    locale: siteConfig.locale,
+    type: 'website',
+    images: [{ url: blogPosts[0].image, alt: blogPosts[0].imageAlt }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title,
+    description,
+    images: [blogPosts[0].image],
+  },
+};
+
+const breadcrumbData = generateBreadcrumbSchema([
+  { name: 'Home', url: '/' },
+  { name: 'Blog', url: '/blog' },
+]);
+
+const blogSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Blog',
+  name: `${contact.businessName} Health & Equipment Blog`,
+  description,
+  url: `${siteConfig.url}/blog`,
+  publisher: { '@id': `${siteConfig.url}/#organization` },
+  blogPost: blogPosts.map((post) => ({
+    '@type': 'BlogPosting',
+    headline: post.title,
+    description: post.excerpt,
+    datePublished: post.publishedAt,
+    image: post.image,
+    url: `${siteConfig.url}/blog/${post.slug}`,
+  })),
+};
+
+export default function BlogPage() {
+  const featuredPost = blogPosts.find((post) => post.featured) ?? blogPosts[0];
+  const latestPosts = blogPosts.filter(
+    (post) => post.slug !== featuredPost.slug
+  );
+  const categories = [...new Set(blogPosts.map((post) => post.category))];
+
+  return (
+    <div className="min-h-screen bg-slate-50 pt-20">
+      <script {...jsonLdScriptProps([breadcrumbData, blogSchema])} />
+
+      <section className="relative overflow-hidden border-b border-teal-100 bg-gradient-to-br from-teal-950 via-teal-900 to-slate-900 text-white">
+        <div className="absolute -right-32 -top-32 h-96 w-96 rounded-full bg-teal-400/10 blur-3xl" />
+        <div className="absolute -bottom-40 left-1/4 h-80 w-80 rounded-full bg-orange-400/10 blur-3xl" />
+        <div className="relative mx-auto max-w-7xl px-4 py-16 md:px-6 md:py-24 lg:px-8">
+          <div className="max-w-3xl">
+            <div className="mb-5 inline-flex items-center gap-2 rounded-full border border-teal-300/25 bg-white/10 px-4 py-2 text-sm font-semibold text-teal-50 backdrop-blur">
+              <Sparkles className="h-4 w-4 text-orange-300" />
+              Practical guidance for everyday care
+            </div>
+            <h1 className="text-4xl font-bold tracking-tight sm:text-5xl md:text-6xl">
+              The Alliance{' '}
+              <span className="text-teal-300">Health & Equipment</span> Blog
+            </h1>
+            <p className="mt-6 max-w-2xl text-lg leading-8 text-slate-200 md:text-xl">
+              Clear, useful answers about mobility, home safety, recovery, and
+              medical equipment—from your local Bay Area specialists.
+            </p>
+
+            <div className="mt-8 flex flex-wrap gap-3 text-sm text-slate-200">
+              <span className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-2">
+                <BookOpen className="h-4 w-4 text-teal-300" /> Daily guides
+              </span>
+              <span className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-2">
+                <MapPin className="h-4 w-4 text-orange-300" /> Bay Area focused
+              </span>
+              <span className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-2">
+                <CheckCircle2 className="h-4 w-4 text-teal-300" /> Easy to
+                understand
+              </span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-4 py-12 md:px-6 md:py-16 lg:px-8">
+        <div className="mb-7 flex flex-col justify-between gap-4 sm:flex-row sm:items-end">
+          <div>
+            <p className="text-sm font-bold uppercase tracking-[0.18em] text-orange-600">
+              Editor&apos;s pick
+            </p>
+            <h2 className="mt-2 text-3xl font-bold tracking-tight text-slate-900">
+              Featured guide
+            </h2>
+          </div>
+          <p className="max-w-lg text-sm leading-6 text-slate-600">
+            Helpful information for patients, families, and caregivers—written
+            to make equipment decisions feel less overwhelming.
+          </p>
+        </div>
+
+        <article className="group grid overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm lg:grid-cols-[1.1fr_0.9fr]">
+          <Link
+            href={`/blog/${featuredPost.slug}`}
+            className="relative min-h-72 overflow-hidden bg-slate-100 lg:min-h-[430px]"
+          >
+            <Image
+              src={featuredPost.image}
+              alt={featuredPost.imageAlt}
+              fill
+              priority
+              className="object-cover transition-transform duration-700 group-hover:scale-[1.03]"
+              sizes="(max-width: 1024px) 100vw, 58vw"
+            />
+            <div className="absolute inset-0 bg-gradient-to-t from-slate-950/35 via-transparent to-transparent" />
+          </Link>
+
+          <div className="flex flex-col justify-center p-7 sm:p-10 lg:p-12">
+            <span className="w-fit rounded-full bg-teal-50 px-3 py-1.5 text-xs font-bold text-teal-700">
+              {featuredPost.category}
+            </span>
+            <div className="mt-5 flex flex-wrap gap-x-5 gap-y-2 text-sm text-slate-500">
+              <span className="flex items-center gap-2">
+                <CalendarDays className="h-4 w-4 text-teal-600" />
+                {formatBlogDate(featuredPost.publishedAt)}
+              </span>
+              <span className="flex items-center gap-2">
+                <Clock3 className="h-4 w-4 text-orange-500" />
+                {featuredPost.readingTime}
+              </span>
+            </div>
+            <h2 className="mt-5 text-3xl font-bold leading-tight tracking-tight text-slate-900 sm:text-4xl">
+              <Link href={`/blog/${featuredPost.slug}`}>
+                {featuredPost.title}
+              </Link>
+            </h2>
+            <p className="mt-5 text-base leading-7 text-slate-600">
+              {featuredPost.excerpt}
+            </p>
+            <Button asChild size="lg" className="mt-7 w-fit">
+              <Link href={`/blog/${featuredPost.slug}`}>
+                Read featured guide <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+          </div>
+        </article>
+      </section>
+
+      <section className="border-y border-slate-200 bg-white">
+        <div className="mx-auto flex max-w-7xl flex-wrap items-center gap-2 px-4 py-5 md:px-6 lg:px-8">
+          <span className="mr-2 text-sm font-bold text-slate-900">
+            Explore topics
+          </span>
+          {categories.map((category) => (
+            <span
+              key={category}
+              className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm font-medium text-slate-600"
+            >
+              {category}
+            </span>
+          ))}
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-4 py-14 md:px-6 md:py-20 lg:px-8">
+        <div className="flex items-end justify-between gap-6">
+          <div>
+            <p className="text-sm font-bold uppercase tracking-[0.18em] text-teal-700">
+              Latest articles
+            </p>
+            <h2 className="mt-2 text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
+              Build confidence, one guide at a time
+            </h2>
+          </div>
+          <span className="hidden text-sm font-medium text-slate-500 sm:block">
+            {blogPosts.length} helpful guides
+          </span>
+        </div>
+
+        <div className="mt-9 grid gap-7 md:grid-cols-2 lg:grid-cols-3">
+          {latestPosts.map((post) => (
+            <BlogCard key={post.slug} post={post} />
+          ))}
+        </div>
+      </section>
+
+      <section className="bg-teal-700 text-white">
+        <div className="mx-auto grid max-w-7xl gap-8 px-4 py-14 md:px-6 lg:grid-cols-[1fr_auto] lg:items-center lg:px-8">
+          <div>
+            <p className="text-sm font-bold uppercase tracking-[0.18em] text-teal-100">
+              Need a personal recommendation?
+            </p>
+            <h2 className="mt-3 text-3xl font-bold tracking-tight">
+              Talk with a local equipment specialist.
+            </h2>
+            <p className="mt-3 max-w-2xl leading-7 text-teal-50">
+              Tell us what you need, how long you need it, and where it will be
+              used. We&apos;ll help you understand the available options.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <Button asChild variant="accent" size="lg">
+              <a href={contact.phone.href}>Call {contact.phone.display}</a>
+            </Button>
+            <Button
+              asChild
+              variant="outline"
+              size="lg"
+              className="border-white bg-transparent text-white hover:bg-white hover:text-teal-800"
+            >
+              <Link href="/contact-us">Contact us</Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,3 +1,4 @@
+import { blogPosts } from '@/lib/blog';
 import {
   getCategories,
   getCategorySlug,
@@ -42,7 +43,20 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'weekly',
       priority: 0.7,
     },
+    {
+      url: `${baseUrl}/blog`,
+      lastModified: currentDate,
+      changeFrequency: 'daily',
+      priority: 0.9,
+    },
   ];
+
+  const blogPages: MetadataRoute.Sitemap = blogPosts.map((post) => ({
+    url: `${baseUrl}/blog/${post.slug}`,
+    lastModified: new Date(post.updatedAt ?? post.publishedAt),
+    changeFrequency: 'monthly' as const,
+    priority: 0.7,
+  }));
 
   // Dynamic category and product pages
   const categories = getCategories();
@@ -69,5 +83,5 @@ export default function sitemap(): MetadataRoute.Sitemap {
     });
   });
 
-  return [...staticPages, ...categoryPages, ...productPages];
+  return [...staticPages, ...blogPages, ...categoryPages, ...productPages];
 }

--- a/src/components/custom/blog/BlogCard.tsx
+++ b/src/components/custom/blog/BlogCard.tsx
@@ -1,0 +1,62 @@
+import { Badge } from '@/components/ui/badge';
+import type { BlogPost } from '@/lib/blog';
+import { formatBlogDate } from '@/lib/blog';
+import { ArrowUpRight, CalendarDays, Clock3 } from 'lucide-react';
+import Image from 'next/image';
+import Link from 'next/link';
+
+type BlogCardProps = {
+  post: BlogPost;
+};
+
+export function BlogCard({ post }: BlogCardProps) {
+  return (
+    <article className="group flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-teal-200 hover:shadow-xl">
+      <Link
+        href={`/blog/${post.slug}`}
+        className="relative block aspect-[16/10] overflow-hidden bg-slate-100"
+        aria-label={`Read ${post.title}`}
+      >
+        <Image
+          src={post.image}
+          alt={post.imageAlt}
+          fill
+          className="object-cover transition-transform duration-500 group-hover:scale-105"
+          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-slate-950/20 to-transparent" />
+        <Badge className="absolute left-4 top-4 border-0 bg-white/95 px-3 py-1 text-teal-700 shadow-sm backdrop-blur">
+          {post.category}
+        </Badge>
+      </Link>
+
+      <div className="flex flex-1 flex-col p-6">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs font-medium text-slate-500">
+          <span className="flex items-center gap-1.5">
+            <CalendarDays className="h-3.5 w-3.5 text-teal-600" />
+            {formatBlogDate(post.publishedAt)}
+          </span>
+          <span className="flex items-center gap-1.5">
+            <Clock3 className="h-3.5 w-3.5 text-orange-500" />
+            {post.readingTime}
+          </span>
+        </div>
+
+        <h2 className="mt-4 text-xl font-bold leading-snug tracking-tight text-slate-900 transition-colors group-hover:text-teal-700">
+          <Link href={`/blog/${post.slug}`}>{post.title}</Link>
+        </h2>
+        <p className="mt-3 flex-1 text-sm leading-6 text-slate-600">
+          {post.excerpt}
+        </p>
+
+        <Link
+          href={`/blog/${post.slug}`}
+          className="mt-5 inline-flex w-fit items-center gap-2 rounded-md text-sm font-bold text-teal-700 transition-colors hover:text-teal-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-4"
+        >
+          Read the guide
+          <ArrowUpRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/src/components/custom/blog/index.ts
+++ b/src/components/custom/blog/index.ts
@@ -1,0 +1,1 @@
+export { BlogCard } from './BlogCard';

--- a/src/components/custom/footer.tsx
+++ b/src/components/custom/footer.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { contact } from '@/data/contact';
 import { ExternalLink, Mail, MapPin, Phone, Star } from 'lucide-react';
+import Link from 'next/link';
 
 export const Footer = () => {
   return (
@@ -200,6 +201,13 @@ export const Footer = () => {
                 >
                   Terms & Conditions
                 </a>
+                <span aria-hidden="true">|</span>
+                <Link
+                  href="/blog"
+                  className="rounded px-1 py-1 hover:text-teal-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                >
+                  Health Blog
+                </Link>
                 <span aria-hidden="true">|</span>
                 <a
                   href="/sitemap.xml"

--- a/src/components/custom/header.tsx
+++ b/src/components/custom/header.tsx
@@ -29,6 +29,7 @@ export const Header = () => {
   const navigation = [
     { name: 'Home', href: '/' },
     { name: 'Products', href: '/products' },
+    { name: 'Blog', href: '/blog' },
     { name: 'About Us', href: '/about-us' },
     { name: 'Reviews', href: '/reviews' },
     { name: 'Contact Us', href: '/contact-us' },
@@ -74,7 +75,9 @@ export const Header = () => {
               aria-label="Main navigation"
             >
               {navigation.map((item) => {
-                const isActive = pathname === item.href;
+                const isActive =
+                  pathname === item.href ||
+                  (item.href !== '/' && pathname.startsWith(`${item.href}/`));
                 return (
                   <Link
                     key={item.name}
@@ -177,7 +180,9 @@ export const Header = () => {
           <div className="fixed inset-x-0 top-20 z-[70] overflow-y-auto max-h-[calc(100vh-5rem)] border-t bg-background shadow-xl xl:hidden">
             <div className="space-y-1 py-4">
               {navigation.map((item) => {
-                const isActive = pathname === item.href;
+                const isActive =
+                  pathname === item.href ||
+                  (item.href !== '/' && pathname.startsWith(`${item.href}/`));
                 return (
                   <Link
                     key={item.name}

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -1,0 +1,371 @@
+import { img } from '@/lib/images';
+
+export type BlogSection = {
+  heading: string;
+  paragraphs: string[];
+  bullets?: string[];
+};
+
+export type BlogPost = {
+  slug: string;
+  title: string;
+  excerpt: string;
+  category: string;
+  publishedAt: string;
+  updatedAt?: string;
+  readingTime: string;
+  image: string;
+  imageAlt: string;
+  featured?: boolean;
+  keywords: string[];
+  introduction: string;
+  sections: BlogSection[];
+  takeaway: string;
+};
+
+export const blogPosts: BlogPost[] = [
+  {
+    slug: 'how-to-choose-the-right-wheelchair',
+    title: 'How to Choose the Right Wheelchair for Everyday Comfort',
+    excerpt:
+      'A practical guide to wheelchair sizing, comfort, transport, and the questions to ask before renting or buying.',
+    category: 'Mobility Guides',
+    publishedAt: '2026-08-05',
+    readingTime: '6 min read',
+    image: img('/hero-section/hero-1.jpg'),
+    imageAlt: 'A modern wheelchair prepared for everyday use',
+    featured: true,
+    keywords: [
+      'choose a wheelchair',
+      'wheelchair rental San Jose',
+      'wheelchair sizing guide',
+      'medical equipment Bay Area',
+    ],
+    introduction:
+      'The right wheelchair should support comfort, safety, mobility, and the routines that matter most. Before choosing a model, take a few minutes to think about the user, the home, transportation, and how often the chair will be used.',
+    sections: [
+      {
+        heading: 'Start with the user and daily routine',
+        paragraphs: [
+          'A chair used for occasional appointments has different requirements than one used throughout the day. Consider whether the person will propel independently, need caregiver assistance, or use the chair primarily for transport.',
+        ],
+        bullets: [
+          'How many hours per day will the chair be used?',
+          'Will it need to fit through narrow doorways or hallways?',
+          'Does it need to fold and fit inside a vehicle?',
+          'Are pressure relief, elevating leg rests, or extra positioning support needed?',
+        ],
+      },
+      {
+        heading: 'Get the fit right',
+        paragraphs: [
+          'Seat width and depth affect both comfort and posture. A chair that is too narrow can create pressure, while one that is too wide may make positioning and self-propulsion more difficult. Footrest height and armrest position matter too.',
+          'A medical professional should assess anyone with complex positioning, skin-integrity, or mobility needs. A local equipment specialist can then help match those recommendations to available models.',
+        ],
+      },
+      {
+        heading: 'Compare manual and transport wheelchairs',
+        paragraphs: [
+          'Standard manual wheelchairs have large rear wheels that may allow independent propulsion. Transport chairs are typically lighter and more compact, but require a caregiver to push them. The best choice depends on independence, caregiver capacity, and travel needs.',
+        ],
+      },
+      {
+        heading: 'Renting can make sense for short-term needs',
+        paragraphs: [
+          'Rental is often useful during recovery, for visiting family, or while deciding which features work best. Purchasing may be more practical for long-term, frequent use. Ask what is included with delivery, setup, maintenance, and accessories before deciding.',
+        ],
+      },
+    ],
+    takeaway:
+      'Choose for fit and daily function—not appearance alone. A short conversation about the user, home, vehicle, and expected length of use can quickly narrow the options.',
+  },
+  {
+    slug: 'hospital-bed-rental-home-checklist',
+    title: 'Hospital Bed Rental at Home: A Room-Ready Checklist',
+    excerpt:
+      'Prepare your home for a hospital bed delivery with a simple checklist covering space, power, access, and caregiver needs.',
+    category: 'Home Care',
+    publishedAt: '2026-08-04',
+    readingTime: '5 min read',
+    image: img('/hero-section/hero-6.jpg'),
+    imageAlt: 'Electric hospital bed for home care',
+    keywords: [
+      'hospital bed rental checklist',
+      'hospital bed rental Bay Area',
+      'home hospital bed setup',
+      'medical bed delivery San Jose',
+    ],
+    introduction:
+      'A little preparation can make hospital bed delivery faster and safer. Use this checklist before the delivery team arrives, and confirm any patient-specific needs with the care team.',
+    sections: [
+      {
+        heading: 'Choose a practical room',
+        paragraphs: [
+          'The room should allow caregivers to reach the bed, provide a clear route to the bathroom when appropriate, and support privacy and comfort. Ground-floor placement may simplify access when stairs are difficult.',
+        ],
+        bullets: [
+          'Clear space around the bed for transfers and care',
+          'Use a nearby grounded electrical outlet',
+          'Remove loose rugs, cords, and clutter from walking paths',
+          'Check doorway, hallway, elevator, and stair dimensions',
+        ],
+      },
+      {
+        heading: 'Plan the delivery route',
+        paragraphs: [
+          'Measure the narrowest doorway and identify tight turns before delivery day. Tell the equipment provider about stairs, elevators, parking restrictions, or building access rules so the team can arrive prepared.',
+        ],
+      },
+      {
+        heading: 'Match the mattress to the care plan',
+        paragraphs: [
+          'Foam, gel, alternating-pressure, and low-air-loss surfaces serve different needs. Pressure-injury risk, transfers, moisture, and comfort should be discussed with a clinician before selecting a support surface.',
+        ],
+      },
+      {
+        heading: 'Ask for a hands-on setup review',
+        paragraphs: [
+          'Before the delivery team leaves, learn how to raise and lower the bed, lock the casters, operate the rails, use the hand control, and respond to a power interruption. Keep the provider’s contact information nearby.',
+        ],
+      },
+    ],
+    takeaway:
+      'Prepare the room, delivery path, outlet, and care plan in advance. The safest setup is one that supports both the patient and the people providing daily care.',
+  },
+  {
+    slug: 'fall-prevention-home-safety-check',
+    title: 'A 10-Minute Home Safety Check to Help Prevent Falls',
+    excerpt:
+      'Walk room by room and spot common trip hazards, poor lighting, and support gaps before they become a problem.',
+    category: 'Safety & Wellness',
+    publishedAt: '2026-08-03',
+    readingTime: '4 min read',
+    image: img('/categories/rollator.png'),
+    imageAlt: 'Rollator mobility aid for safer walking support',
+    keywords: [
+      'fall prevention at home',
+      'senior home safety checklist',
+      'walker and rollator safety',
+      'Bay Area home medical equipment',
+    ],
+    introduction:
+      'Falls can happen when several small risks overlap: a dim hallway, a loose rug, rushed movement, or an aid that does not fit correctly. A quick home check can reveal easy improvements.',
+    sections: [
+      {
+        heading: 'Clear the path',
+        paragraphs: [
+          'Walk the routes used most often—from the bed to the bathroom, favorite chair, kitchen, and front door. Look at the floor from the perspective of someone using a walker, rollator, or wheelchair.',
+        ],
+        bullets: [
+          'Secure or remove loose rugs and curled edges',
+          'Move electrical cords out of walkways',
+          'Keep frequently used items within easy reach',
+          'Create enough turning space for the mobility aid',
+        ],
+      },
+      {
+        heading: 'Improve light and contrast',
+        paragraphs: [
+          'Add night-lights along the route to the bathroom and make switches easy to reach. Contrasting colors on steps and thresholds can make changes in floor height easier to see.',
+        ],
+      },
+      {
+        heading: 'Check the mobility aid',
+        paragraphs: [
+          'Worn tips, loose brakes, incorrect handle height, and cluttered storage bags can affect stability. If a person’s strength, balance, or gait has changed, ask a clinician to reassess the most appropriate aid.',
+        ],
+      },
+      {
+        heading: 'Pay attention to transitions',
+        paragraphs: [
+          'Transfers in and out of bed, the shower, and a favorite chair are common moments of risk. Stable seating, appropriate grab bars, and clinician-recommended transfer equipment can help.',
+        ],
+      },
+    ],
+    takeaway:
+      'Start with the most-used walking routes, then address lighting, clutter, floor hazards, and equipment fit. Small changes can make everyday movement feel more predictable.',
+  },
+  {
+    slug: 'knee-scooter-vs-crutches',
+    title: 'Knee Scooter vs. Crutches: Which Fits Your Recovery?',
+    excerpt:
+      'Compare stability, upper-body effort, space, and lifestyle considerations for common non-weight-bearing mobility options.',
+    category: 'Recovery',
+    publishedAt: '2026-08-02',
+    readingTime: '5 min read',
+    image: img('/categories/knee-scooters.png'),
+    imageAlt: 'Knee scooter used during lower-leg recovery',
+    keywords: [
+      'knee scooter vs crutches',
+      'knee scooter rental San Jose',
+      'non weight bearing mobility aid',
+      'foot surgery recovery equipment',
+    ],
+    introduction:
+      'Both crutches and knee scooters can support non-weight-bearing recovery, but they place different demands on the body and home environment. Your clinician’s restrictions come first.',
+    sections: [
+      {
+        heading: 'Where a knee scooter can help',
+        paragraphs: [
+          'A knee scooter supports the injured leg on a padded platform and may reduce the upper-body effort required by crutches. It can be useful on smooth, level surfaces for people who can safely balance and steer.',
+        ],
+      },
+      {
+        heading: 'Where crutches may be more practical',
+        paragraphs: [
+          'Crutches are easier to carry, navigate on stairs when properly trained, and use in compact spaces. They require adequate strength, coordination, and technique.',
+        ],
+      },
+      {
+        heading: 'Consider your environment',
+        paragraphs: [
+          'Measure narrow doorways, identify thresholds, and think about how you will manage transportation. Knee scooters are not designed for every surface, and neither option should be used beyond the restrictions given by your clinician.',
+        ],
+        bullets: [
+          'Home layout and stair access',
+          'Balance and upper-body strength',
+          'Work, school, and transportation needs',
+          'Expected recovery timeline',
+        ],
+      },
+      {
+        heading: 'Try the equipment before deciding',
+        paragraphs: [
+          'A correctly adjusted device should feel stable and manageable. Ask for instruction on fit, braking, turning, and safe transfers. Stop and contact your care team if use causes pain or feels unsafe.',
+        ],
+      },
+    ],
+    takeaway:
+      'The best device is the one your clinician approves and you can use safely in your actual environment. A short-term rental can be useful when recovery needs may change.',
+  },
+  {
+    slug: 'rent-or-buy-medical-equipment',
+    title: 'Should You Rent or Buy Medical Equipment?',
+    excerpt:
+      'Use expected duration, changing needs, maintenance, and total cost to make a more confident equipment decision.',
+    category: 'Equipment Basics',
+    publishedAt: '2026-08-01',
+    readingTime: '5 min read',
+    image: img('/categories/mobility-scooters.png'),
+    imageAlt: 'Mobility equipment available for rental or purchase',
+    keywords: [
+      'rent or buy medical equipment',
+      'medical equipment rental Bay Area',
+      'DME rental San Jose',
+      'home medical supplies',
+    ],
+    introduction:
+      'Renting and buying can both be sensible choices. The right answer depends on how long the equipment is needed, whether the user’s needs may change, and what services are included.',
+    sections: [
+      {
+        heading: 'When renting may be a good fit',
+        paragraphs: [
+          'Rental often works well for short recoveries, visiting relatives, travel, temporary home care, or a trial period before purchase. It can also simplify service when maintenance is included.',
+        ],
+      },
+      {
+        heading: 'When buying may make more sense',
+        paragraphs: [
+          'Purchase may offer better long-term value for equipment used regularly over an extended period. It can also allow more personalization, provided the chosen equipment continues to fit the user’s needs.',
+        ],
+      },
+      {
+        heading: 'Compare the complete cost',
+        paragraphs: [
+          'Look beyond the daily or monthly rate. Ask about delivery, setup, pickup, cleaning, accessories, maintenance, deposits, and minimum rental periods. For purchases, ask about warranty and service options.',
+        ],
+        bullets: [
+          'Expected length of use',
+          'Likelihood that needs or sizing will change',
+          'Delivery, setup, and training',
+          'Maintenance and warranty coverage',
+        ],
+      },
+      {
+        heading: 'Confirm coverage separately',
+        paragraphs: [
+          'Insurance policies and eligibility vary. Contact the plan directly to confirm covered items, documentation requirements, approved suppliers, and out-of-pocket costs before relying on reimbursement.',
+        ],
+      },
+    ],
+    takeaway:
+      'Estimate the duration of use and compare the full cost of ownership or rental. Include service, changing needs, and convenience—not only the sticker price.',
+  },
+  {
+    slug: 'safe-rollator-setup-guide',
+    title: 'Five Rollator Setup Checks Before the First Walk',
+    excerpt:
+      'Check handle height, brakes, seat, folding locks, and walking posture before putting a new rollator into daily use.',
+    category: 'Mobility Guides',
+    publishedAt: '2026-07-31',
+    readingTime: '4 min read',
+    image: img('/categories/rollator.png'),
+    imageAlt: 'Four-wheel rollator with seat and hand brakes',
+    keywords: [
+      'how to adjust a rollator',
+      'rollator safety guide',
+      'walker with seat setup',
+      'rollator rental San Jose',
+    ],
+    introduction:
+      'A rollator can support mobility and provide a convenient seat, but correct adjustment and brake use are essential. Follow the manufacturer’s instructions and any guidance from your clinician.',
+    sections: [
+      {
+        heading: 'Set a comfortable handle height',
+        paragraphs: [
+          'When standing upright inside the frame, the handles are commonly adjusted near wrist-crease height with the arms relaxed. Individual needs differ, so a clinician’s recommendation should take priority.',
+        ],
+      },
+      {
+        heading: 'Test both brake modes',
+        paragraphs: [
+          'Practice squeezing the hand brakes to slow and engaging the parking brakes before sitting. Both sides should hold securely and release smoothly.',
+        ],
+      },
+      {
+        heading: 'Inspect the frame and seat',
+        paragraphs: [
+          'Confirm the frame is fully opened and locked, the seat is secure, and accessories do not interfere with the wheels or brakes. Follow the stated user and storage weight limits.',
+        ],
+      },
+      {
+        heading: 'Practice turns and transitions',
+        paragraphs: [
+          'Start on a clear, level surface. Keep the rollator close enough to avoid leaning forward, take wider turns, and approach thresholds slowly. Always lock the brakes before sitting or standing.',
+        ],
+        bullets: [
+          'Wear supportive, non-slip footwear',
+          'Keep bags within the manufacturer-approved storage area',
+          'Do not use the seat as a transport chair',
+          'Recheck brake tension and wheel condition regularly',
+        ],
+      },
+    ],
+    takeaway:
+      'A few minutes spent adjusting and practicing can make a rollator easier to control. Reassess the fit if posture, balance, or strength changes.',
+  },
+];
+
+export function getBlogPost(slug: string): BlogPost | undefined {
+  return blogPosts.find((post) => post.slug === slug);
+}
+
+export function getRelatedPosts(post: BlogPost, limit = 3): BlogPost[] {
+  return blogPosts
+    .filter((candidate) => candidate.slug !== post.slug)
+    .sort((a, b) => {
+      const aMatches = a.category === post.category ? 1 : 0;
+      const bMatches = b.category === post.category ? 1 : 0;
+      return bMatches - aMatches;
+    })
+    .slice(0, limit);
+}
+
+export function formatBlogDate(date: string): string {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(`${date}T12:00:00Z`));
+}


### PR DESCRIPTION
## Summary

- add a responsive, SEO-focused medical equipment and home healthcare blog landing page
- add six starter articles with reusable article and card components
- add Blog links to desktop/mobile navigation and the footer
- add canonical metadata, Open Graph data, BlogPosting structured data, and sitemap entries
- include related guides, local conversion CTAs, and a medical-information disclaimer

## Why

The site needs an evergreen content destination that can target informational search intent around medical equipment, mobility, home safety, recovery, and caregiver education. The reusable article data structure makes it straightforward to publish additional posts on a regular cadence.

## User impact

Visitors gain practical educational resources and clear paths to relevant equipment help. Search engines gain crawlable article URLs, structured metadata, internal links, and updated sitemap coverage.

## Validation

- `npm run lint` (passes with one pre-existing Google Analytics warning)
- `npx tsc --noEmit`
- `npm run build`
- responsive browser verification for desktop and mobile navigation
- image, article route, and sitemap response checks
