### PR TITLE
Adjust Bathroom Aids image position

### DIFF
--- a/src/components/custom/ProductCard.tsx
+++ b/src/components/custom/ProductCard.tsx
@@ -98,7 +98,10 @@ export const ProductCard = ({
               alt={data.name}
               fill
               priority={priority}
-              className="object-cover transition-transform duration-500 group-hover:scale-105"
+              className={cn(
+                'object-cover transition-transform duration-500 group-hover:scale-105',
+                data.name === 'Bathroom Aids' && 'object-[center_35%]'
+              )}
               sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
             />
           </div>

--- a/src/components/custom/rental-categories/CategoryCard.tsx
+++ b/src/components/custom/rental-categories/CategoryCard.tsx
@@ -71,7 +71,10 @@ export const CategoryCard = ({
             alt={name}
             fill
             sizes="(max-width: 640px) 100vw, (max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw"
-            className="object-cover transition-transform duration-300 group-hover:scale-105"
+            className={cn(
+              'object-cover transition-transform duration-300 group-hover:scale-105',
+              name === 'Bathroom Aids' && 'object-[center_35%]'
+            )}
             priority={false}
           />
 


### PR DESCRIPTION
## Summary

- Shift the Bathroom Aids card image focal point upward from the default center to `35%`.
- Apply the adjustment only to Bathroom Aids on the homepage rental grid and Products category grid.

## Why

The default center crop removed too much of the top of the supplied photo. The adjusted focal point reveals the subject's full head while keeping the tub transfer bench centered.

## Impact

No other product images or layouts are changed.

## Validation

- `npm run lint` (passes with one pre-existing Google Analytics warning)
- `npx tsc --noEmit`
- `npm run build` (65/65 static pages generated)
- Browser verification confirms `object-position: 50% 35%` and successful image loading on both cards
