### PR TITLE
Remove seated knee walker product

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -24,7 +24,7 @@ Our primary business is rentals (approximately 90% of revenue). We offer same-da
 - Patient Lifts: Manual and electric Hoyer lifts, manual and electric stand assists
 - Mobility Scooters: Small, standard, lightweight, and heavy-duty scooters
 - Lift Chairs: Reclining power lift chairs
-- Knee Scooters: Seated and standard knee walkers
+- Knee Scooters: Standard knee walkers
 - Rollators: Standard and bariatric rolling walkers
 - CPM Machines: Continuous Passive Motion machines for post-surgery knee rehabilitation
 - PureWick System: Non-invasive external catheter system

--- a/src/lib/data/categories.json
+++ b/src/lib/data/categories.json
@@ -85,12 +85,6 @@
       "description": "Easy, stable mobility for lower leg injuries without using crutches.",
       "products": [
         {
-          "id": 401,
-          "name": "Seated Knee Walker",
-          "description": "Allows seated use for comfort during longer recovery.",
-          "image": "/knee-scooters/seated-knee-walker.png"
-        },
-        {
           "id": 402,
           "name": "Standard Knee Walker",
           "description": "Easy mobility solution for foot or ankle injuries.",


### PR DESCRIPTION
## Summary

- Remove the Seated Knee Walker from the Knee Scooters catalog.
- Keep the Standard Knee Walker as the only product in that category.
- Update the machine-readable product summary to match.

## Why

The seated knee scooter option should no longer be displayed or offered on the official product site.

## Impact

- The Knee Scooters category will show one product.
- The generated Seated Knee Walker product route will be removed from the production build and sitemap.

## Validation

- Catalog assertion confirms exactly one product: `Standard Knee Walker`
- `git diff --check`
- The local Next.js build could not complete because macOS File Provider stalled while reading offloaded dependency files; the production deployment will be monitored through Vercel after merge.
